### PR TITLE
CustomDialogでエラーが出ないように修正

### DIFF
--- a/lib/widgets/custom_dialog.dart
+++ b/lib/widgets/custom_dialog.dart
@@ -75,53 +75,55 @@ class CustomDialogBox extends StatelessWidget {
                 ),
               ),
               Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Container(
-                    height: 64,
-                    width: 170,
-                    decoration: const BoxDecoration(
-                      border: Border(
-                        top: BorderSide(
-                          color: CustomColors.light,
-                          width: 1,
+                  Expanded(
+                    child: Container(
+                      height: 64,
+                      decoration: const BoxDecoration(
+                        border: Border(
+                          top: BorderSide(
+                            color: CustomColors.light,
+                            width: 1,
+                          ),
                         ),
                       ),
-                    ),
-                    child: TextButton(
-                      onPressed: () => tapEvent2(),
-                      child: const Text(
-                        "いいえ",
-                        style: TextStyle(
-                          fontWeight: FontWeight.bold,
-                          fontSize: 24,
-                          color: CustomColors.deep,
+                      child: TextButton(
+                        onPressed: () => tapEvent2(),
+                        child: const Text(
+                          "いいえ",
+                          style: TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 24,
+                            color: CustomColors.deep,
+                          ),
                         ),
                       ),
                     ),
                   ),
-                  Container(
-                    height: 64,
-                    width: 170,
-                    decoration: const BoxDecoration(
-                      border: Border(
-                        top: BorderSide(
-                          color: CustomColors.light,
-                          width: 1,
-                        ),
-                        left: BorderSide(
-                          color: CustomColors.light,
-                          width: 1,
+                  Expanded(
+                    child: Container(
+                      height: 64,
+                      decoration: const BoxDecoration(
+                        border: Border(
+                          top: BorderSide(
+                            color: CustomColors.light,
+                            width: 1,
+                          ),
+                          left: BorderSide(
+                            color: CustomColors.light,
+                            width: 1,
+                          ),
                         ),
                       ),
-                    ),
-                    child: TextButton(
-                      onPressed: () => tapEvent1(),
-                      child: const Text(
-                        "はい",
-                        style: TextStyle(
-                          fontWeight: FontWeight.bold,
-                          fontSize: 24,
+                      child: TextButton(
+                        onPressed: () => tapEvent1(),
+                        child: const Text(
+                          "はい",
+                          style: TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 24,
+                          ),
                         ),
                       ),
                     ),


### PR DESCRIPTION
## 解決したIssue
- close #198 

## 変更点
<!--できるだけ詳しく箇条書きで-->
- CustomDialogのボタンのUIを、エラーが出ないように修正した。
- 具体的には、Widthを直接指定していたものから、Expandedを使用したものに変更した。

## スクリーンショット
<!--UI等の変更であれば必ず-->
before
![Untitled](https://user-images.githubusercontent.com/51878546/134094918-3b546f68-a57e-482b-9032-fecc9b50f693.png)

after
![image](https://user-images.githubusercontent.com/51878546/134094891-f782795b-5965-4bfd-baa5-b42d092cb697.png)
